### PR TITLE
Rollback: Retore to commit d8d8edd

### DIFF
--- a/services/staging/test.yml
+++ b/services/staging/test.yml
@@ -18,6 +18,7 @@ services:
         methods:
           - POST
           - GET
+          - DELETE
         protocols:
           - http
         paths:


### PR DESCRIPTION
Este PR executa um rollback na pasta `services/`, restaurando seu conteúdo para o estado anterior ao último merge. Isso foi acionado devido ao PR #70.